### PR TITLE
feat: initial commit for module

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 
 
 # DevOps
-* @devops
+* @southernlights-tech/devops

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
 # terraform-modules-template-public
-Public terraform module for 
+This Terraform module creates an AWS IAM role with configurable trust policies, inline policies, and attached managed policies. It allows for flexible IAM role creation for various AWS services and applications.
+
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.service_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.service_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.managed_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_append_environment_to_role_name"></a> [append\_environment\_to\_role\_name](#input\_append\_environment\_to\_role\_name) | Append environment name to role name | `bool` | `true` | no |
+| <a name="input_assume_role_policy_document"></a> [assume\_role\_policy\_document](#input\_assume\_role\_policy\_document) | The policy document that grants permission to assume the role. | `string` | n/a | yes |
+| <a name="input_env_short"></a> [env\_short](#input\_env\_short) | Short string for environment | `string` | n/a | yes |
+| <a name="input_managed_policies"></a> [managed\_policies](#input\_managed\_policies) | List of managed policy ARNs to attach to the resource | `list(string)` | `[]` | no |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | The maximum session duration for the role, in seconds. | `number` | `3600` | no |
+| <a name="input_path"></a> [path](#input\_path) | The path for the role. | `string` | `"/service-role/"` | no |
+| <a name="input_policy_description"></a> [policy\_description](#input\_policy\_description) | A description for the IAM policy. | `string` | n/a | yes |
+| <a name="input_policy_statements"></a> [policy\_statements](#input\_policy\_statements) | The statements to include in the IAM policy. | <pre>list(object({<br/>    Effect    = string<br/>    Action    = list(string)<br/>    Resource  = list(string)<br/>    Condition = optional(any)<br/>  }))</pre> | `[]` | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the IAM role. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_outputs"></a> [outputs](#output\_outputs) | n/a |
+<!-- END_TF_DOCS -->

--- a/examples/basic-role/main.tf
+++ b/examples/basic-role/main.tf
@@ -1,0 +1,40 @@
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "iam_role_basic" {
+  source = "../../"
+
+  role_name = "my-basic-service-role"
+  env_short = "dev"
+
+  assume_role_policy_document = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      },
+    ]
+  })
+
+  policy_statements = [
+    {
+      Effect   = "Allow"
+      Action   = ["s3:GetObject"]
+      Resource = ["arn:aws:s3:::my-example-bucket/*"]
+    },
+  ]
+}
+
+output "role_arn" {
+  value = module.iam_role_basic.outputs.role_arn
+}
+
+output "role_name" {
+  value = module.iam_role_basic.outputs.role_name
+}

--- a/examples/managed-policy-role/main.tf
+++ b/examples/managed-policy-role/main.tf
@@ -1,0 +1,34 @@
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "iam_role_managed" {
+  source = "../../"
+
+  role_name = "my-managed-policy-role"
+  env_short = "prod"
+
+  assume_role_policy_document = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      },
+    ]
+  })
+
+  managed_policies = ["AmazonS3ReadOnlyAccess"]
+}
+
+output "role_arn" {
+  value = module.iam_role_managed.outputs.role_arn
+}
+
+output "role_name" {
+  value = module.iam_role_managed.outputs.role_name
+}

--- a/init.tf
+++ b/init.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  aws_policy_prefix = format("arn:%s:iam::aws:policy", join("", data.aws_partition.current[*].partition))
+  managed_policies  = sort(var.managed_policies)
+
+  role_name = var.append_environment_to_role_name ? "${var.role_name}-${var.env_short}" : var.role_name
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,37 @@
+resource "aws_iam_role" "service_role" {
+  name                 = local.role_name
+  assume_role_policy   = var.assume_role_policy_document
+  path                 = var.path
+  max_session_duration = var.max_session_duration # Optional, can be set in variables
+}
+
+resource "aws_iam_policy" "service_policy" {
+  count       = length(var.policy_statements) > 0 ? 1 : 0
+  name        = "${var.role_name}-${var.env_short}"
+  description = var.policy_description
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      for statement in var.policy_statements : {
+        Effect    = statement.Effect
+        Action    = statement.Action
+        Resource  = statement.Resource
+        Condition = statement.Condition != null ? statement.Condition : {}
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "policy_attachment" {
+  count      = length(var.policy_statements) > 0 ? 1 : 0
+  role       = aws_iam_role.service_role.name
+  policy_arn = aws_iam_policy.service_policy[0].arn
+}
+
+data "aws_partition" "current" {}
+
+resource "aws_iam_role_policy_attachment" "managed_policies" {
+  count      = length(var.managed_policies)
+  policy_arn = format("%s/%s", local.aws_policy_prefix, local.managed_policies[count.index])
+  role       = aws_iam_role.service_role.name
+}

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,8 @@
+output "outputs" {
+  value = {
+    policy_arn  = length(var.policy_statements) > 0 ? aws_iam_policy.service_policy[0].arn : ""
+    policy_name = length(var.policy_statements) > 0 ? aws_iam_policy.service_policy[0].name : ""
+    role_arn    = aws_iam_role.service_role.arn
+    role_name   = aws_iam_role.service_role.name
+  }
+}

--- a/vars.tf
+++ b/vars.tf
@@ -1,0 +1,54 @@
+variable "role_name" {
+  description = "The name of the IAM role."
+  type        = string
+}
+
+variable "assume_role_policy_document" {
+  description = "The policy document that grants permission to assume the role."
+  type        = string
+}
+
+variable "policy_statements" {
+  description = "The statements to include in the IAM policy."
+  type = list(object({
+    Effect    = string
+    Action    = list(string)
+    Resource  = list(string)
+    Condition = optional(any)
+  }))
+  default = []
+}
+
+variable "policy_description" {
+  description = "A description for the IAM policy."
+  type        = string
+}
+
+variable "path" {
+  description = "The path for the role."
+  type        = string
+  default     = "/service-role/"
+}
+
+variable "max_session_duration" {
+  description = "The maximum session duration for the role, in seconds."
+  type        = number
+  default     = 3600
+}
+
+variable "env_short" {
+  description = "Short string for environment"
+  type        = string
+}
+
+variable "managed_policies" {
+  type        = list(string)
+  default     = []
+  description = "List of managed policy ARNs to attach to the resource"
+}
+
+variable "append_environment_to_role_name" {
+  type        = bool
+  description = "Append environment name to role name"
+  default     = true
+}


### PR DESCRIPTION
### Feature: New Terraform Module for AWS IAM Role Management

This pull request introduces a new Terraform module designed to simplify the
creation and management of AWS IAM roles. This module provides a flexible and
configurable way to define IAM roles for various AWS services and applications.

**Key Features:**

* **Configurable IAM Role:** Create AWS IAM roles with custom
      `assume_role_policy_document`.
* **Inline Policy Support:** Easily define inline IAM policies using the
    `policy_statements` input, allowing granular control over permissions.
* **Managed Policy Attachment:** Attach multiple AWS managed policies to the
      role via the `managed_policies` input.
* **Dynamic Role Naming:** Optionally append the environment short code to the
    role name for better organization.
* **Comprehensive Documentation:** The `README.md` has been updated with
      auto-generated documentation for inputs, outputs, and resources.
* **Usage Examples:** Includes `basic-role` and `managed-policy-role` examples to demonstrate module usage.
